### PR TITLE
Support for configurable theme directories and different layout names

### DIFF
--- a/src/AspNet.Mvc.Theming.Sample/AspNet.Mvc.Theming.Sample.csproj
+++ b/src/AspNet.Mvc.Theming.Sample/AspNet.Mvc.Theming.Sample.csproj
@@ -188,7 +188,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>0</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:47651/</IISUrl>
+          <IISUrl>http://localhost:47653/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/src/AspNet.Mvc.Theming/Configuration/IThemingConfiguration.cs
+++ b/src/AspNet.Mvc.Theming/Configuration/IThemingConfiguration.cs
@@ -4,6 +4,7 @@
     {
         string ThemeDirectory { get; set; }
         string DefaultTheme { get; set; }
+        string DefaultLayoutName { get; set; }
         IThemeResolver ThemeResolver { get; set; }
     }
 }

--- a/src/AspNet.Mvc.Theming/Configuration/ThemingConfiguration.cs
+++ b/src/AspNet.Mvc.Theming/Configuration/ThemingConfiguration.cs
@@ -5,12 +5,15 @@
         public ThemingConfiguration()
         {
             DefaultTheme = "Default";
-
+            DefaultLayoutName = "_Layout";
             ThemeResolver = new DefaultThemeResolver();
         }
 
         public string ThemeDirectory { get; set; }
+
         public string DefaultTheme { get; set; }
+
+        public string DefaultLayoutName { get; set; }
 
         public IThemeResolver ThemeResolver { get; set; }
     }


### PR DESCRIPTION
I updated the support for configuring the theme directory.  I also added support for layout files other than `_layout`.  The default layout is still `_layout` and that can be configured using the new `DefaultLayoutName` propery in `IThemingConfiguration`.

I was trying to keep the file count low for the pull request.  So I did not create a sample web application that is configured to use a different theme directory and different layout names.  Let me know if you want an example application included.  

I also changed the port used for the Theming.Sample project.  The Theming.Sample and Theming.ThemeSelectionSample projects were using the same port number, which was causing conflicts in IIS Express.
